### PR TITLE
Fix errors in Voronoi algorithm

### DIFF
--- a/Algorithms/Voronoi_algorithm.py
+++ b/Algorithms/Voronoi_algorithm.py
@@ -41,8 +41,8 @@ class _VoronoiCell:
 
         dimension = len(self.vector[0])
 
-        position_tolerance = parameters[0]
-        momentum_tolerance = parameters[1]
+        position_tolerance = parameters[1]
+        momentum_tolerance = parameters[0]
         position_vector_idx = dimensions.dimension_position
 
         avg_values = []
@@ -54,15 +54,15 @@ class _VoronoiCell:
                 values_dimension.append(self.vector[j][i])
                 weights_dimension.append(self.weights[j])
 
-            std = weighted_std(values_dimension, weights_dimension)
-            if i <= position_vector_idx:
+            std = numpy.sqrt(weighted_variance(values_dimension, weights_dimension))
+            if i < position_vector_idx:
                 avg_values.append(std/position_tolerance)
             else:
                 avg_values.append(std/momentum_tolerance)
 
         max_idx, max_avg = get_max_coef(avg_values)
 
-        return max_avg
+        return max_idx, max_avg
 
     def divide(self, devide_hyperlane):
 
@@ -131,13 +131,16 @@ def get_max_coef(avg_values):
     return max_idx, max_value
 
 
-def weighted_std(values, weights):
+def weighted_variance(values, weights):
     """
-    Return the weighted average and standard deviation.
+    Return the weighted variance.
 
     values, weights -- Numpy ndarrays with the same shape.
 
     """
+
+    if len(values) == 1:
+        return 0
 
     weighted_average = 0
 
@@ -154,7 +157,6 @@ def weighted_std(values, weights):
     weighted_sq_average = weighted_sq_average / sum_weights
     # Fast and numerically precise:
     variance = weighted_sq_average - weighted_average * weighted_average
-
     return variance
 
 
@@ -173,7 +175,7 @@ def _merge(data, weights, parameters, dimensions):
     while len(cells) > 0:
         cell = cells[0]
 
-        max_avg = cell.get_coeff_var(parameters, dimensions)
+        max_idx, max_avg = cell.get_coeff_var(parameters, dimensions)
         needs_subdivision = (max_avg > 1)
 
         if needs_subdivision:
@@ -216,8 +218,8 @@ def check_needs_subdivision(parameters, max_avg, max_idx, dimensions):
 
     """
 
-    position_tolerance = parameters[0]
-    momentum_tolerance = parameters[1]
+    position_tolerance = parameters[1]
+    momentum_tolerance = parameters[0]
     position_vector_idx = dimensions.dimension_position
 
 

--- a/Algorithms/Voronoi_algorithm.py
+++ b/Algorithms/Voronoi_algorithm.py
@@ -35,11 +35,15 @@ class _VoronoiCell:
         self.vector = numpy.array(data)
         self.weights = numpy.array(weigths)
 
-    def get_coeff_var(self):
+    def get_coeff_var(self, parameters, dimensions):
 
         """Get max variance coefficient of Voronoi cell"""
 
         dimension = len(self.vector[0])
+
+        position_tolerance = parameters[0]
+        momentum_tolerance = parameters[1]
+        position_vector_idx = dimensions.dimension_position
 
         avg_values = []
 
@@ -51,11 +55,14 @@ class _VoronoiCell:
                 weights_dimension.append(self.weights[j])
 
             std = weighted_std(values_dimension, weights_dimension)
-            avg_values.append(std)
+            if i <= position_vector_idx:
+                avg_values.append(std/position_tolerance)
+            else:
+                avg_values.append(std/momentum_tolerance)
 
         max_idx, max_avg = get_max_coef(avg_values)
 
-        return max_idx, max_avg
+        return max_avg
 
     def divide(self, devide_hyperlane):
 
@@ -163,14 +170,11 @@ def _merge(data, weights, parameters, dimensions):
     result_vector = []
     result_weights = []
     cells = [initial_cell]
-    print(len(data))
-    print(dimensions.dimension_position)
-    print(dimensions.dimension_momentum)
     while len(cells) > 0:
         cell = cells[0]
 
-        max_idx, max_avg = cell.get_coeff_var()
-        needs_subdivision = check_needs_subdivision(parameters, max_avg, max_idx, dimensions)
+        max_avg = cell.get_coeff_var(parameters, dimensions)
+        needs_subdivision = (max_avg > 1)
 
         if needs_subdivision:
             first_part_cell, secound_part_cell = cell.divide(max_idx)

--- a/reduction_main.py
+++ b/reduction_main.py
@@ -892,7 +892,6 @@ if __name__ == "__main__":
         tolerance = [args.momentum_tol, args.position_lol]
         parameters = Voronoi_algorithm.VoronoiMergingAlgorithmParameters(tolerance)
         voronoi_algorithm(args.hdf, args.hdf_re, args.momentum_tol, args.position_lol)
-        base_reduction_function(args.hdf, args.hdf_re, "voronoi", parameters)
 
     elif args.algorithm == 'voronoi_prob':
         parameters = Voronoi_probabilistic_algorithm.Voronoi_probabilistic_algorithm_parameters(args.reduction_percent, args.divide_particles)


### PR DESCRIPTION
Hello!

I've found a few errors in the Voronoi algorithm. I'm putting my fixes in this PR (it seems to be working fine now; at least in the sense that the results I get are consistent with what I expected), feel free to modify anything before merging. The errors were the following:

- In the function `get_coeff_var`, the std (actually the variance) of the position was compared to the std of the momentum in SI units. This essentially made the tolerance for the momentum disregarded. Now the standard deviations are normalized by the tolerances so that we can safely compare the position std with the momentum std.

- The function `weighted_std` actually returned the variance (the std squared). I've renamed this function `weighted_variance` for clarity and I've added a square root when it is called in `get_coeff_var`. I've also slightly modified this function so that it returns 0 when the length of the input array is 1 (otherwise it may return a (very small) negative number due to machine precision errors, which turn into a `nan` when performing the above-mentioned square-root).